### PR TITLE
[#155323126] Fixes app-backend error while connecting to redis

### DIFF
--- a/infrastructure/kubernetes/app-backend.yml
+++ b/infrastructure/kubernetes/app-backend.yml
@@ -38,8 +38,6 @@ spec:
           value: "production"
         - name: "API_URL"
           value: "https://agid-apim-test.azure-api.net/api/v1"
-        - name: "REDIS_URL"
-          value: "redis://redis"
         - name: "SAML_CALLBACK_URL"
           value: "https://app-backend.k8s.test.cd.teamdigitale.it/assertionConsumerService"
         - name: "SAML_ISSUER"


### PR DESCRIPTION
Fixes the following error:

```
yarn run v1.3.2
$ ./node_modules/.bin/babel-node src/server.js
info: Session token duration set to 3600 seconds
[awilix] The registerClass and other "register*" shortcuts have been deprecated and will be removed in v3.
Use "container.register({ name: asClass(target) })" instead. See https://github.com/jeffijoe/awilix/issues/60
info: Reading SAML private key file from ./certs/key.pem
info: Reading SAML certificate file from ./certs/cert.pem
info: Listening on port 80
events.js:183
      throw er; // Unhandled 'error' event
      ^

Error: Redis connection to redis:6379 failed - getaddrinfo EAI_AGAIN redis:6379
    at Object._errnoException (util.js:1022:11)
    at errnoException (dns.js:55:15)
    at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:92:26)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```