### PR TITLE
Switch backend to the production API gateway

### DIFF
--- a/infrastructure/kubernetes/app-backend.yml
+++ b/infrastructure/kubernetes/app-backend.yml
@@ -41,7 +41,7 @@ spec:
         - name: "API_BASE_PATH"
           value: "/api/v1"
         - name: "API_URL"
-          value: "https://agid-apim-test.azure-api.net/api/v1"
+          value: "https://api.cd.italia.it/api/v1"
         - name: "API_KEY"
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Actually we use two API management. The one used by administration is the production one (api.cd.italia.it), the one used by the app backend is the test one (agid-apim-test.azure-api.net). As, to save credits, we downgraded the test tier from "standard" (500€ month) to developer (40€ month) and we have a "premium" tier in the production gateway (2k month) we could save 500€ month by pointing the API backend to the production one.

This change, if accepted, will require to change the api-key to the one of a new account into the backend kubernetes configuration (manually, using kubectl). 